### PR TITLE
(doc) Minor typos in documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ In order to use the commands for this addin, you will need to include either of 
 ```
 
 ```csharp
-#tools coveralls.io
+#tool coveralls.io
 ```
 
 This will instruct Cake to download the package from NuGet and install it into the Cake Tool's folder, and from there, the executable will be available to your script.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ Within your build script, you will need to add the following (normally near the 
 and either one of the following:
 
 ```csharp
-#tools coveralls.net
+#tool coveralls.net
 ```
 
 ```csharp

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
-site_name: Cake.Gem
+site_name: Cake.Coveralls
 theme: readthedocs
-repo_url: https://github.com/gep13/Cake.Gem
+repo_url: https://github.com/gep13/Cake.Coveralls
 
 pages:
 - Home: index.md


### PR DESCRIPTION
Fixes a few minor typos in the documentation.

Thanks for the addin!
