### PR TITLE
Reaction to Wyam changes in Cake.Recipe, moves most Wyam settings to setup.cake

### DIFF
--- a/config.wyam
+++ b/config.wyam
@@ -1,5 +1,3 @@
 System.Globalization.CultureInfo.DefaultThreadCurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-GB");
-Settings.Host = "cake-contrib.github.io";
-Settings.LinkRoot = "Cake.Coveralls";
-GlobalMetadata["BaseEditUrl"] = "https://github.com/cake-contrib/Cake.Coveralls/tree/develop/docs/input";
-GlobalMetadata["SourceFiles"] = "Source/**/{!bin,!obj,!packages,!*.Tests,}/**/*.cs";
+Settings.Host = GlobalMetadata.String("Host");
+Settings.LinkRoot = GlobalMetadata.String("LinkRoot");

--- a/setup.cake
+++ b/setup.cake
@@ -8,7 +8,10 @@ BuildParameters.SetParameters(context: Context,
                             title: "Cake.Coveralls",
                             repositoryOwner: "cake-contrib",
                             repositoryName: "Cake.Coveralls",
-                            appVeyorAccountName: "cakecontrib");
+                            appVeyorAccountName: "cakecontrib",
+                            webHost: "cake-contrib.github.io",
+                            webLinkRoot: "Cake.Coveralls",
+                            webBaseEditUrl: "https://github.com/cake-contrib/Cake.Coveralls/tree/develop/docs/input/");
 
 BuildParameters.PrintParamters(Context);
 


### PR DESCRIPTION
This change is dependent on https://github.com/cake-contrib/Cake.Recipe/pull/33 - don't merge this until that PR is merged and deployed. Also note any existing download of the Cake.Recipe package in the tools folder will have to be cleaned.