### PR TITLE
Change JobId type from int to string

### DIFF
--- a/Source/Cake.Coveralls.Tests/CoverallsNetRunnerTests.cs
+++ b/Source/Cake.Coveralls.Tests/CoverallsNetRunnerTests.cs
@@ -275,7 +275,7 @@ namespace Cake.Coveralls.Tests
             public void Should_Set_Job_Id()
             {
                 // Given
-                var fixture = new CoverallsNetRunnerFixture { Settings = { JobId = 123456 } };
+                var fixture = new CoverallsNetRunnerFixture { Settings = { JobId = "123456" } };
 
                 // When
                 var result = fixture.Run();

--- a/Source/Cake.Coveralls/CoverallsNetRunner.cs
+++ b/Source/Cake.Coveralls/CoverallsNetRunner.cs
@@ -147,10 +147,10 @@ namespace Cake.Coveralls
                 builder.AppendQuoted(settings.CommitMessage);
             }
 
-            if (settings.JobId != 0)
+            if (!string.IsNullOrEmpty(settings.JobId))
             {
                 builder.Append("--jobId");
-                builder.Append(settings.JobId.ToString());
+                builder.Append(settings.JobId);
             }
 
             if (!string.IsNullOrWhiteSpace(settings.ServiceName))

--- a/Source/Cake.Coveralls/CoverallsNetSettings.cs
+++ b/Source/Cake.Coveralls/CoverallsNetSettings.cs
@@ -62,7 +62,7 @@ namespace Cake.Coveralls
         /// Gets or sets the Job Id to provide to coveralls.io.
         /// </summary>
         /// <remarks>Default is 0.</remarks>
-        public int JobId { get; set; }
+        public string JobId { get; set; }
 
         /// <summary>
         /// Gets or sets the service name for the coverage report.


### PR DESCRIPTION
Coveralls.Net supports setting a string JobId, for builds with non-integer
build IDs. This should be reflected in the settings for Cake.Coveralls as
well.