### PR TITLE
GH-44: Update Cake.Coveralls to target Cake v1.0.0

### DIFF
--- a/Source/Cake.Coveralls.Tests/Cake.Coveralls.Tests.csproj
+++ b/Source/Cake.Coveralls.Tests/Cake.Coveralls.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.33.0" />
-    <PackageReference Include="Cake.Testing" Version="0.33.0" />
+    <PackageReference Include="Cake.Core" Version="1.0.0" />
+    <PackageReference Include="Cake.Testing" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="NSubstitute" Version="2.0.2" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/Source/Cake.Coveralls/Cake.Coveralls.csproj
+++ b/Source/Cake.Coveralls/Cake.Coveralls.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #44