### PR TITLE
(#190) Add support for Cake v5.0.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+*.sh    text eol=lf
 
 # Custom for Visual Studio
 *.cs     diff=csharp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,24 @@ jobs:
           verbosity: Normal
           cake-version: tool-manifest
 
+      # The demo/ folders exercise the just-built addin DLL under
+      # Cake-major-matching cake.tool / Cake.Frosting versions. They
+      # run in their OWN tool/package context (independent of
+      # recipe.cake's cake.tool, which is constrained by Cake.Recipe's
+      # runtime). Both consume the addin from
+      # BuildArtifacts/temp/_PublishedLibraries/ populated by
+      # DotNetCore-Pack.
+
+      - name: Run demo/script
+        if: success()
+        shell: pwsh
+        run: ./demo/script/build.ps1
+
+      - name: Run demo/frosting
+        if: success()
+        shell: pwsh
+        run: ./demo/frosting/build.ps1
+
       - name: Upload Issues-Report
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:

--- a/Source/Cake.Coveralls.Tests/Cake.Coveralls.Tests.csproj
+++ b/Source/Cake.Coveralls.Tests/Cake.Coveralls.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
-    <DebugType>full</DebugType>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>..\Cake.Coveralls.ruleset</CodeAnalysisRuleSet>
@@ -10,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="4.0.0" />
-    <PackageReference Include="Cake.Testing" Version="4.0.0" />
+    <PackageReference Include="Cake.Core" Version="5.0.0" />
+    <PackageReference Include="Cake.Testing" Version="5.0.0" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Source/Cake.Coveralls/Cake.Coveralls.csproj
+++ b/Source/Cake.Coveralls/Cake.Coveralls.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -23,7 +23,7 @@
       <Description>Cake AddIn that extends Cake with ability to post Code Coverage results to Coveralls.io.</Description>
       <PackageLicenseExpression>MIT</PackageLicenseExpression>
       <PackageProjectUrl>https://github.com/cake-contrib/Cake.Coveralls/</PackageProjectUrl>
-      <PackageTags>cake;script;build;coveralls;cake-addin;cake-build;addin</PackageTags>
+      <PackageTags>cake;cake-build;cake-addin;addin;script;build;coveralls</PackageTags>
       <RepositoryUrl>https://github.com/cake-contrib/Cake.Coveralls.git</RepositoryUrl>
       <PackageReleaseNotes>https://github.com/cake-contrib/Cake.Coveralls/releases/tag/$(Version)</PackageReleaseNotes>
       <CodeAnalysisRuleSet>..\Cake.Coveralls.ruleset</CodeAnalysisRuleSet>
@@ -36,7 +36,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Cake.Core" Version="4.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="CakeContrib.Guidelines" Version="1.7.0" PrivateAssets="All" />
     <PackageReference Include="IDisposableAnalyzers" Version="4.0.8">
       <PrivateAssets>all</PrivateAssets>

--- a/demo/frosting/.gitignore
+++ b/demo/frosting/.gitignore
@@ -1,0 +1,4 @@
+bin/
+obj/
+output/
+.vscode/

--- a/demo/frosting/build.ps1
+++ b/demo/frosting/build.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = 'Stop'
+
+Set-Location -LiteralPath $PSScriptRoot
+
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = '1'
+$env:DOTNET_CLI_TELEMETRY_OPTOUT = '1'
+$env:DOTNET_NOLOGO = '1'
+
+dotnet run --project build/Build.csproj -- @args
+exit $LASTEXITCODE;

--- a/demo/frosting/build.sh
+++ b/demo/frosting/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_NOLOGO=1
+
+dotnet run --project build/Build.csproj -- "$@"

--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <RunWorkingDirectory>$(MSBuildProjectDirectory)\</RunWorkingDirectory>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Cake.Coveralls">
+      <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.Coveralls\net8.0\Cake.Coveralls.dll</HintPath>
+    </Reference>
+    <PackageReference Include="Cake.Frosting" Version="5.1.0" />
+  </ItemGroup>
+</Project>

--- a/demo/frosting/build/BuildContext.cs
+++ b/demo/frosting/build/BuildContext.cs
@@ -1,0 +1,13 @@
+using Cake.Core;
+using Cake.Frosting;
+
+namespace Build
+{
+    public class BuildContext : FrostingContext
+    {
+        public BuildContext(ICakeContext context)
+            : base(context)
+        {
+        }
+    }
+}

--- a/demo/frosting/build/DefaultTask.cs
+++ b/demo/frosting/build/DefaultTask.cs
@@ -1,0 +1,13 @@
+using Build.Tasks;
+using Cake.Frosting;
+
+namespace Build
+{
+    [TaskName("Default")]
+    [IsDependentOn(typeof(SettingsCoverallsIoTask))]
+    [IsDependentOn(typeof(SettingsCoverallsNetTask))]
+    [IsDependentOn(typeof(ReportTypeEnumsTask))]
+    public sealed class DefaultTask : FrostingTask
+    {
+    }
+}

--- a/demo/frosting/build/Program.cs
+++ b/demo/frosting/build/Program.cs
@@ -1,0 +1,14 @@
+using Cake.Frosting;
+
+namespace Build
+{
+    public static class Program
+    {
+        public static int Main(string[] args)
+        {
+            return new CakeHost()
+                .UseContext<BuildContext>()
+                .Run(args);
+        }
+    }
+}

--- a/demo/frosting/build/Tasks/ReportTypeEnumsTask.cs
+++ b/demo/frosting/build/Tasks/ReportTypeEnumsTask.cs
@@ -1,0 +1,38 @@
+using Cake.Common.Diagnostics;
+using Cake.Coveralls;
+using Cake.Frosting;
+
+namespace Build.Tasks
+{
+    [TaskName("ReportType-Enums")]
+    public sealed class ReportTypeEnumsTask : FrostingTask<BuildContext>
+    {
+        public override void Run(BuildContext context)
+        {
+            var ioTypes = new[]
+            {
+                CoverallsIoReportType.OpenCover,
+                CoverallsIoReportType.Cobertura,
+            };
+
+            var netTypes = new[]
+            {
+                CoverallsNetReportType.OpenCover,
+                CoverallsNetReportType.DynamicCodeCoverage,
+                CoverallsNetReportType.Monocov,
+            };
+
+            if (ioTypes.Length != 2)
+            {
+                throw new System.Exception("CoverallsIoReportType: expected 2 values");
+            }
+
+            if (netTypes.Length != 3)
+            {
+                throw new System.Exception("CoverallsNetReportType: expected 3 values");
+            }
+
+            context.Information("ReportType enums OK (Io: {0} values, Net: {1} values)", ioTypes.Length, netTypes.Length);
+        }
+    }
+}

--- a/demo/frosting/build/Tasks/SettingsCoverallsIoTask.cs
+++ b/demo/frosting/build/Tasks/SettingsCoverallsIoTask.cs
@@ -1,0 +1,44 @@
+using Cake.Common.Diagnostics;
+using Cake.Coveralls;
+using Cake.Frosting;
+
+namespace Build.Tasks
+{
+    [TaskName("Settings-CoverallsIo")]
+    public sealed class SettingsCoverallsIoTask : FrostingTask<BuildContext>
+    {
+        public override void Run(BuildContext context)
+        {
+            var settings = new CoverallsIoSettings
+            {
+                Debug = true,
+                FullSources = true,
+                RepoToken = "fake-token",
+                ReportType = CoverallsIoReportType.Cobertura,
+            };
+
+            if (!settings.Debug)
+            {
+                throw new System.Exception("Debug round-trip failed");
+            }
+
+            if (!settings.FullSources)
+            {
+                throw new System.Exception("FullSources round-trip failed");
+            }
+
+            if (settings.RepoToken != "fake-token")
+            {
+                throw new System.Exception("RepoToken round-trip failed");
+            }
+
+            if (settings.ReportType != CoverallsIoReportType.Cobertura)
+            {
+                throw new System.Exception("ReportType round-trip failed");
+            }
+
+            context.Information("CoverallsIoSettings OK (Debug={0}, FullSources={1}, ReportType={2})",
+                settings.Debug, settings.FullSources, settings.ReportType);
+        }
+    }
+}

--- a/demo/frosting/build/Tasks/SettingsCoverallsNetTask.cs
+++ b/demo/frosting/build/Tasks/SettingsCoverallsNetTask.cs
@@ -1,0 +1,99 @@
+using Cake.Common.Diagnostics;
+using Cake.Common.IO;
+using Cake.Coveralls;
+using Cake.Frosting;
+
+namespace Build.Tasks
+{
+    [TaskName("Settings-CoverallsNet")]
+    public sealed class SettingsCoverallsNetTask : FrostingTask<BuildContext>
+    {
+        public override void Run(BuildContext context)
+        {
+            var settings = new CoverallsNetSettings
+            {
+                OutputFilePath = context.File("./coverage.xml"),
+                UseRelativePaths = true,
+                BaseFilePath = context.Directory("./Source"),
+                RepoToken = "fake-token",
+                RepoTokenVariable = "COVERALLS_REPO_TOKEN",
+                CommitId = "abc123",
+                CommitBranch = "develop",
+                CommitAuthor = "Cake",
+                CommitEmail = "cake@example.com",
+                CommitMessage = "exercise script",
+                JobId = "42",
+                ServiceName = "coveralls.net",
+                TreatUploadErrorsAsWarnings = true,
+            };
+
+            if (settings.OutputFilePath == null)
+            {
+                throw new System.Exception("OutputFilePath round-trip failed");
+            }
+
+            if (!settings.UseRelativePaths)
+            {
+                throw new System.Exception("UseRelativePaths round-trip failed");
+            }
+
+            if (settings.BaseFilePath == null)
+            {
+                throw new System.Exception("BaseFilePath round-trip failed");
+            }
+
+            if (settings.RepoToken != "fake-token")
+            {
+                throw new System.Exception("RepoToken round-trip failed");
+            }
+
+            if (settings.RepoTokenVariable != "COVERALLS_REPO_TOKEN")
+            {
+                throw new System.Exception("RepoTokenVariable round-trip failed");
+            }
+
+            if (settings.CommitId != "abc123")
+            {
+                throw new System.Exception("CommitId round-trip failed");
+            }
+
+            if (settings.CommitBranch != "develop")
+            {
+                throw new System.Exception("CommitBranch round-trip failed");
+            }
+
+            if (settings.CommitAuthor != "Cake")
+            {
+                throw new System.Exception("CommitAuthor round-trip failed");
+            }
+
+            if (settings.CommitEmail != "cake@example.com")
+            {
+                throw new System.Exception("CommitEmail round-trip failed");
+            }
+
+            if (settings.CommitMessage != "exercise script")
+            {
+                throw new System.Exception("CommitMessage round-trip failed");
+            }
+
+            if (settings.JobId != "42")
+            {
+                throw new System.Exception("JobId round-trip failed");
+            }
+
+            if (settings.ServiceName != "coveralls.net")
+            {
+                throw new System.Exception("ServiceName round-trip failed");
+            }
+
+            if (!settings.TreatUploadErrorsAsWarnings)
+            {
+                throw new System.Exception("TreatUploadErrorsAsWarnings round-trip failed");
+            }
+
+            context.Information("CoverallsNetSettings OK (CommitId={0}, JobId={1}, ServiceName={2})",
+                settings.CommitId, settings.JobId, settings.ServiceName);
+        }
+    }
+}

--- a/demo/script/.config/dotnet-tools.json
+++ b/demo/script/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+    "version": 1,
+    "isRoot": true,
+    "tools": {
+        "cake.tool": {
+            "version": "5.1.0",
+            "commands": [
+                "dotnet-cake"
+            ]
+        }
+    }
+}

--- a/demo/script/build.ps1
+++ b/demo/script/build.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = 'Stop'
+
+Set-Location -LiteralPath $PSScriptRoot
+
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = '1'
+$env:DOTNET_CLI_TELEMETRY_OPTOUT = '1'
+$env:DOTNET_NOLOGO = '1'
+
+dotnet tool restore
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+dotnet cake coveralls.cake @args
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/demo/script/build.sh
+++ b/demo/script/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_NOLOGO=1
+
+dotnet tool restore
+
+dotnet cake coveralls.cake "$@"

--- a/demo/script/coveralls.cake
+++ b/demo/script/coveralls.cake
@@ -1,4 +1,4 @@
-#reference "BuildArtifacts/temp/_PublishedLibraries/Cake.Coveralls/net8.0/Cake.Coveralls.dll"
+#reference "../../BuildArtifacts/temp/_PublishedLibraries/Cake.Coveralls/net8.0/Cake.Coveralls.dll"
 
 // Self-contained exercise of Cake.Coveralls' settings + alias surface.
 // Verifies the addin loads, the settings types can be constructed and

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "8.0.100",
+      "version": "9.0.100",
       "rollForward": "latestFeature"
     }
   }


### PR DESCRIPTION
Closes #190.

First in the per-Cake-major catch-up arc — brings Cake.Coveralls' Cake reference from `4.0.0` to `5.0.0` and retrofits the `demo/{script,frosting}` pattern that wasn't standardised yet when the baseline PR (#191) merged.

## Commits

1. **(#190) Cake v5.0.0 catch-up: bump Cake.Core/Testing to 5.0.0** — addin csproj `Cake.Core 4.0.0 → 5.0.0`, TFMs `net6.0;net7.0;net8.0 → net8.0;net9.0`, canonicalised `PackageTags`; tests csproj `Cake.Core / Cake.Testing 4.0.0 → 5.0.0`, TFM `net6.0;net7.0;net8.0 → net8.0`, dropped `<DebugType>full</DebugType>`; `global.json` SDK `8.0.100 → 9.0.100`.
2. **(#190) Move coveralls.cake to demo/script/ with own cake.tool pin** — `git mv` to `demo/script/`, adjust `#reference` path, pin `cake.tool 5.1.0` in tool manifest, add `build.ps1`/`build.sh` wrappers, add `*.sh text eol=lf` to `.gitattributes`.
3. **(#190) Add demo/frosting harness with Cake.Frosting 5.1.0** — full `demo/frosting/` (net8.0 + Cake.Frosting 5.1.0 + Settings-CoverallsIo + Settings-CoverallsNet + ReportType-Enums tasks mirroring the script's assertions).
4. **(#190) build.yml: wire Run demo/{script,frosting} steps** — both demos run on every matrix leg after the recipe.cake build completes; `shell: pwsh` for cross-platform.

## Why cake.tool 5.1.0 / Cake.Frosting 5.1.0 in demo/

Per workspace standard: demo pins use the LATEST of the Cake major (looked up live against NuGet flat-container before each pin), while addin/tests `Cake.{Core,Testing}` stay on `5.0.0` — that's the per-major contract anchor that Renovate is configured to leave alone.

## Why tests TFM dropped to single net8.0

The tests project's `TargetFrameworks` was `net6.0;net7.0;net8.0` since the 4.0.0 release. Workspace standard is for tests to track the LOWEST supported TFM the addin ships at the current Cake major; with `net6.0` + `net7.0` trimmed from the addin's list (both EOL), the rotation crosses to `net8.0` (single TFM). 43/43 existing tests pass.

## Local verification

* `dotnet cake recipe.cake --target=DotNetCore-Pack` — `Cake.Coveralls.<ver>.nupkg` + `Cake.Coveralls.<ver>.snupkg` both produced cleanly (no NuGet-portable-PDB warning — confirms the `<DebugType>full</DebugType>` removal landed).
* `dotnet cake recipe.cake --target=DotNetCore-Test` — 43/43 tests passing on `net8.0`.
* `./demo/script/build.ps1` — Settings-CoverallsIo + Settings-CoverallsNet + ReportType-Enums all pass.
* `./demo/frosting/build.ps1` — Settings-CoverallsIo + Settings-CoverallsNet + ReportType-Enums all pass.

## Out of scope

* Further Cake-major bumps (separate issue/PR per major; #190 covers Cake 5 only).
* Issue #188 stderr-redirect feature (pending PR #189) — separate fix release after the Cake 5 + 6 catch-up arc completes.
* `TWITTER_*` / `WYAM_*` env-var scrub from `build.yml` — workspace TODO has this as a separate batched follow-up sweep, not bundled with catch-ups.
* CCG0009 ("recommended version is 6.0.0") — expected; will resolve in the follow-up Cake 6 catch-up PR.
* Pre-existing first-party `SA1208` / `CS8625` warnings — Eazfuscator's pattern was to clear these in the Cake 6 PR as a separate commit; matching that here.