### PR TITLE
(#150) Remove GRM 0.17.0 pin in recipe.cake

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -16,9 +16,6 @@ BuildParameters.SetParameters(context: Context,
 
 BuildParameters.PrintParameters(Context);
 
-ToolSettings.SetToolPreprocessorDirectives(
-                            gitReleaseManagerGlobalTool: "#tool dotnet:?package=GitReleaseManager.Tool&version=0.17.0");
-
 ToolSettings.SetToolSettings(context: Context,
                             testCoverageFilter: "+[*]* -[xunit.*]* -[Cake.Core]* -[Cake.Testing]* -[*.Tests]*",
                             testCoverageExcludeByAttribute: "*.ExcludeFromCodeCoverage*",


### PR DESCRIPTION
Closes #150.

Cake.Recipe 4.0.0's bundled default for `gitReleaseManagerGlobalTool` is `0.20.0` (Cake.Recipe `Source/Cake.Recipe/Content/toolsettings.cake:52`); `recipe.cake` was overriding it back to `0.17.0`, which crashes during the `Publish-GitHub-Release` task with:

```
[FTL] Value was either too large or too small for an Int32.
GitReleaseManager.Core.Exceptions.ApiException: ...
   at System.Convert.ThrowInt32OverflowException()
   at Octokit.PocoJsonSerializerStrategy.DeserializeObject(...)
   at GitReleaseManager.Core.VcsService.AddIssueCommentsAsync(...)
   at GitReleaseManager.Core.VcsService.CloseMilestoneAsync(...)
```

GRM 0.17.0 ships with an Octokit that deserializes GitHub issue/comment IDs as `Int32`, but modern GitHub IDs exceed `Int32.MaxValue` (≈2.1 B). GRM 0.20.0 has the fixed Octokit. With this override removed, the default takes effect.

## Hit on v5.0.0

Surfaced on the v5.0.0 tag-push 2026-05-07 (run [25479806883](https://github.com/cake-contrib/Cake.Coveralls/actions/runs/25479806883)). The release itself shipped successfully:

- ✅ `Cake.Coveralls.5.0.0.nupkg` + `Cake.Coveralls.5.0.0.snupkg` pushed to NuGet at 06:34:14 / 06:34:16.
- ✅ GitHub release `v5.0.0` created.
- ✅ Milestone 5.0.0 closed (`closed_at: 2026-05-07T06:34:25Z`).
- ❌ Auto-comments on issue #190 + PR #194 announcing the release — lost (cosmetic).

Once this lands, future tagged releases will exercise the fixed GRM and the auto-comments will work.

## Local verification

`dotnet cake recipe.cake --target=Show-Info` parses + runs cleanly with the override removed.

## Out of scope

- The same stale-GRM-pin pattern exists in three other workspace addins (Cake.Discord 0.18.0, Cake.VsCode.Recipe 0.19.0, Chocolatey.Cake.Recipe 0.20.0 — last one redundant since it matches the default). Tracked separately in the workspace TODO.