### PR TITLE
(#195) Add support for Cake v6.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,12 +82,13 @@ jobs:
           cake-version: tool-manifest
 
       # The demo/ folders exercise the just-built addin DLL under
-      # Cake-major-matching cake.tool / Cake.Frosting versions. They
-      # run in their OWN tool/package context (independent of
-      # recipe.cake's cake.tool, which is constrained by Cake.Recipe's
-      # runtime). Both consume the addin from
-      # BuildArtifacts/temp/_PublishedLibraries/ populated by
-      # DotNetCore-Pack.
+      # Cake-major-matching cake.tool / Cake.Frosting / Cake.Sdk
+      # versions. They run in their OWN tool/package context
+      # (independent of recipe.cake's cake.tool, which is constrained
+      # by Cake.Recipe's runtime). demo/script and demo/frosting
+      # consume the addin from BuildArtifacts/temp/_PublishedLibraries/
+      # populated by DotNetCore-Pack; demo/sdk builds the addin from
+      # source via the #:project directive in cake.cs.
 
       - name: Run demo/script
         if: success()
@@ -98,6 +99,12 @@ jobs:
         if: success()
         shell: pwsh
         run: ./demo/frosting/build.ps1
+
+      - name: Run demo/sdk
+        if: success()
+        shell: pwsh
+        working-directory: ./demo/sdk
+        run: dotnet cake.cs
 
       - name: Upload Issues-Report
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5

--- a/Source/Cake.Coveralls.Tests/Cake.Coveralls.Tests.csproj
+++ b/Source/Cake.Coveralls.Tests/Cake.Coveralls.Tests.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="5.0.0" />
-    <PackageReference Include="Cake.Testing" Version="5.0.0" />
+    <PackageReference Include="Cake.Core" Version="6.0.0" />
+    <PackageReference Include="Cake.Testing" Version="6.0.0" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Source/Cake.Coveralls.Tests/CoverallsIoRunnerFixture.cs
+++ b/Source/Cake.Coveralls.Tests/CoverallsIoRunnerFixture.cs
@@ -11,7 +11,7 @@ namespace Cake.Coveralls.Tests
             CodeCoverageReportFilePath = FileSystem.GetFile("/temp/coverage.xml").Path.FullPath;
         }
 
-        public FilePath CodeCoverageReportFilePath { get; private set; }
+        public FilePath? CodeCoverageReportFilePath { get; private set; }
 
         public void WithoutCodeCoverageReportFilePath()
         {
@@ -21,7 +21,7 @@ namespace Cake.Coveralls.Tests
         protected override void RunTool()
         {
             var tool = new CoverallsIoRunner(FileSystem, Environment, ProcessRunner, Tools);
-            tool.Run(CodeCoverageReportFilePath, Settings);
+            tool.Run(CodeCoverageReportFilePath!, Settings);
         }
     }
 }

--- a/Source/Cake.Coveralls.Tests/CoverallsIoRunnerTests.cs
+++ b/Source/Cake.Coveralls.Tests/CoverallsIoRunnerTests.cs
@@ -1,6 +1,6 @@
-﻿using Cake.Core;
+﻿using System;
+using Cake.Core;
 using Cake.Testing;
-using System;
 using Xunit;
 
 namespace Cake.Coveralls.Tests
@@ -15,7 +15,7 @@ namespace Cake.Coveralls.Tests
                 // Given
                 var fixture = new CoverallsIoRunnerFixture
                 {
-                    Settings = null,
+                    Settings = null!,
                 };
 
                 // When

--- a/Source/Cake.Coveralls.Tests/CoverallsNetRunnerFixture.cs
+++ b/Source/Cake.Coveralls.Tests/CoverallsNetRunnerFixture.cs
@@ -12,7 +12,7 @@ namespace Cake.Coveralls.Tests
             ReportType = CoverallsNetReportType.OpenCover;
         }
 
-        public FilePath CodeCoverageReportFilePath { get; private set; }
+        public FilePath? CodeCoverageReportFilePath { get; private set; }
 
         public CoverallsNetReportType ReportType { get; }
 
@@ -24,7 +24,7 @@ namespace Cake.Coveralls.Tests
         protected override void RunTool()
         {
             var tool = new CoverallsNetRunner(FileSystem, Environment, ProcessRunner, Tools);
-            tool.Run(CodeCoverageReportFilePath, ReportType, Settings);
+            tool.Run(CodeCoverageReportFilePath!, ReportType, Settings);
         }
     }
 }

--- a/Source/Cake.Coveralls.Tests/CoverallsNetRunnerTests.cs
+++ b/Source/Cake.Coveralls.Tests/CoverallsNetRunnerTests.cs
@@ -1,6 +1,6 @@
-﻿using Cake.Core;
+﻿using System;
+using Cake.Core;
 using Cake.Testing;
-using System;
 using Xunit;
 
 namespace Cake.Coveralls.Tests
@@ -15,7 +15,7 @@ namespace Cake.Coveralls.Tests
                 // Given
                 var fixture = new CoverallsNetRunnerFixture
                 {
-                    Settings = null,
+                    Settings = null!,
                 };
 
                 // When

--- a/Source/Cake.Coveralls/Cake.Coveralls.csproj
+++ b/Source/Cake.Coveralls/Cake.Coveralls.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -36,7 +36,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Cake.Core" Version="5.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="6.0.0" PrivateAssets="All" />
     <PackageReference Include="CakeContrib.Guidelines" Version="1.7.0" PrivateAssets="All" />
     <PackageReference Include="IDisposableAnalyzers" Version="4.0.8">
       <PrivateAssets>all</PrivateAssets>

--- a/Source/Cake.Coveralls/CoverallsIoRunner.cs
+++ b/Source/Cake.Coveralls/CoverallsIoRunner.cs
@@ -1,8 +1,8 @@
-﻿using Cake.Core;
+﻿using System;
+using System.Collections.Generic;
+using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
-using System;
-using System.Collections.Generic;
 
 namespace Cake.Coveralls
 {

--- a/Source/Cake.Coveralls/CoverallsNetRunner.cs
+++ b/Source/Cake.Coveralls/CoverallsNetRunner.cs
@@ -1,8 +1,8 @@
-﻿using Cake.Core;
+﻿using System;
+using System.Collections.Generic;
+using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
-using System;
-using System.Collections.Generic;
 
 namespace Cake.Coveralls
 {

--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -9,6 +9,6 @@
     <Reference Include="Cake.Coveralls">
       <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.Coveralls\net8.0\Cake.Coveralls.dll</HintPath>
     </Reference>
-    <PackageReference Include="Cake.Frosting" Version="5.1.0" />
+    <PackageReference Include="Cake.Frosting" Version="6.1.0" />
   </ItemGroup>
 </Project>

--- a/demo/script/.config/dotnet-tools.json
+++ b/demo/script/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
     "isRoot": true,
     "tools": {
         "cake.tool": {
-            "version": "5.1.0",
+            "version": "6.1.0",
             "commands": [
                 "dotnet-cake"
             ]

--- a/demo/sdk/cake.cs
+++ b/demo/sdk/cake.cs
@@ -1,0 +1,127 @@
+#!/usr/bin/env dotnet
+#:sdk Cake.Sdk@6.1.1
+#:project ../../Source/Cake.Coveralls/Cake.Coveralls.csproj
+#:property Nullable=enable
+
+// Nullable=enable propagates `<Nullable>enable</Nullable>` to the
+// SDK's synthetic csproj so the addin's `string?` / `FilePath?` /
+// `DirectoryPath?` annotations on CoverallsIoSettings /
+// CoverallsNetSettings load in the right context (silences CS8632).
+//
+// NoWarn=CS8603 silences "Possible null reference return" warnings
+// emitted from Cake.Sdk's generated `CakeMethodAliases.g.cs` — the
+// source generator doesn't currently propagate the addin's `?`
+// annotations into the synthesized wrappers, so it reports the
+// nullable returns as suspicious. Not actionable from our code;
+// upstream issue against Cake.Sdk.
+#:property NoWarn=CS8603
+
+// Cake SDK consumer demo for Cake.Coveralls. Runs as a file-based
+// .NET program (introduced in .NET 10) using the Cake.Sdk
+// directives. The #:project directive above lets the SDK build the
+// addin from source rather than referencing a published nupkg.
+//
+// To run locally:
+//   cd demo/sdk
+//   dotnet cake.cs
+//
+// Runs the same three checks the script and frosting demos run.
+
+using Cake.Coveralls;
+
+Task("Default")
+    .IsDependentOn("Settings-CoverallsIo")
+    .IsDependentOn("Settings-CoverallsNet")
+    .IsDependentOn("ReportType-Enums");
+
+Task("Settings-CoverallsIo")
+    .Does(() =>
+{
+    var settings = new CoverallsIoSettings
+    {
+        Debug = true,
+        FullSources = true,
+        RepoToken = "fake-token",
+        ReportType = CoverallsIoReportType.Cobertura,
+    };
+
+    AssertThat(settings.Debug, "Debug should be true");
+    AssertThat(settings.FullSources, "FullSources should be true");
+    AssertThat(settings.RepoToken == "fake-token", "RepoToken roundtrip mismatch");
+    AssertThat(settings.ReportType == CoverallsIoReportType.Cobertura, "ReportType roundtrip mismatch");
+
+    Information("CoverallsIoSettings OK (Debug={0}, FullSources={1}, ReportType={2})",
+        settings.Debug, settings.FullSources, settings.ReportType);
+});
+
+Task("Settings-CoverallsNet")
+    .Does(() =>
+{
+    var settings = new CoverallsNetSettings
+    {
+        OutputFilePath = File("./coverage.xml"),
+        UseRelativePaths = true,
+        BaseFilePath = Directory("./Source"),
+        RepoToken = "fake-token",
+        RepoTokenVariable = "COVERALLS_REPO_TOKEN",
+        CommitId = "abc123",
+        CommitBranch = "develop",
+        CommitAuthor = "Cake",
+        CommitEmail = "cake@example.com",
+        CommitMessage = "exercise script",
+        JobId = "42",
+        ServiceName = "coveralls.net",
+        TreatUploadErrorsAsWarnings = true,
+    };
+
+    AssertThat(settings.OutputFilePath != null, "OutputFilePath should be set");
+    AssertThat(settings.UseRelativePaths, "UseRelativePaths should be true");
+    AssertThat(settings.BaseFilePath != null, "BaseFilePath should be set");
+    AssertThat(settings.RepoToken == "fake-token", "RepoToken roundtrip mismatch");
+    AssertThat(settings.RepoTokenVariable == "COVERALLS_REPO_TOKEN", "RepoTokenVariable roundtrip mismatch");
+    AssertThat(settings.CommitId == "abc123", "CommitId roundtrip mismatch");
+    AssertThat(settings.CommitBranch == "develop", "CommitBranch roundtrip mismatch");
+    AssertThat(settings.CommitAuthor == "Cake", "CommitAuthor roundtrip mismatch");
+    AssertThat(settings.CommitEmail == "cake@example.com", "CommitEmail roundtrip mismatch");
+    AssertThat(settings.CommitMessage == "exercise script", "CommitMessage roundtrip mismatch");
+    AssertThat(settings.JobId == "42", "JobId roundtrip mismatch");
+    AssertThat(settings.ServiceName == "coveralls.net", "ServiceName roundtrip mismatch");
+    AssertThat(settings.TreatUploadErrorsAsWarnings, "TreatUploadErrorsAsWarnings should be true");
+
+    Information("CoverallsNetSettings OK (CommitId={0}, JobId={1}, ServiceName={2})",
+        settings.CommitId, settings.JobId, settings.ServiceName);
+});
+
+Task("ReportType-Enums")
+    .Does(() =>
+{
+    var ioTypes = new[]
+    {
+        CoverallsIoReportType.OpenCover,
+        CoverallsIoReportType.Cobertura,
+    };
+
+    var netTypes = new[]
+    {
+        CoverallsNetReportType.OpenCover,
+        CoverallsNetReportType.DynamicCodeCoverage,
+        CoverallsNetReportType.Monocov,
+    };
+
+    AssertThat(ioTypes.Length == 2, "CoverallsIoReportType: expected 2 values");
+    AssertThat(netTypes.Length == 3, "CoverallsNetReportType: expected 3 values");
+
+    Information("ReportType enums OK (Io: {0} values, Net: {1} values)", ioTypes.Length, netTypes.Length);
+});
+
+RunTarget("Default");
+
+// ----- Helpers (must come AFTER top-level statements per CS8803) -----
+
+static void AssertThat(bool condition, string message)
+{
+    if (!condition)
+    {
+        throw new Exception("Assertion failed: " + message);
+    }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "9.0.100",
+      "version": "10.0.100",
       "rollForward": "latestFeature"
     }
   }


### PR DESCRIPTION
Closes #195.

Sixth and final per-Cake-major release. Closes the catch-up arc.

## Commits

1. **(#195) First-party SA1208 + CS8625 / CS8604 warning cleanup** — clears the warnings carried since v4.0.0 that were left in place during the Cake-5 catch-up (#194). 6 SA1208 reorderings (using-directive ordering) + 4 CS8625 (`null` -> non-nullable) + 2 CS8604 (possible null reference argument). Build now reports zero first-party warnings (CCG0009 still flags Cake.Core 5.0.0 → 6.0.0; resolves in commit 2). Mirrors the Eazfuscator pattern (PR #24, commit 5a39b12).
2. **(#195) Cake v6.0.0 catch-up: bump Cake.Core/Testing to 6.0.0 + add demo/sdk** — addin csproj `Cake.Core 5.0.0 → 6.0.0`, TFMs `net8.0;net9.0 → net8.0;net9.0;net10.0`; tests csproj `Cake.Core / Cake.Testing 5.0.0 → 6.0.0`, TFM stays at `net8.0` (lowest TFM the addin still ships, so no rotation per memory `feedback_tests_tfm_rotation`); `global.json` SDK `9.0.100 → 10.0.100`; `demo/script/.config/dotnet-tools.json` cake.tool `5.1.0 → 6.1.0`; `demo/frosting/build/Build.csproj` Cake.Frosting `5.1.0 → 6.1.0`; **`demo/sdk/cake.cs` (NEW)** — Cake.Sdk consumer demo using `Cake.Sdk@6.1.1` with `#:sdk` and `#:project` directives; `build.yml` new `Run demo/sdk` step. CCG0009 cleared.

## Why Cake.Sdk 6.1.1 in demo/sdk

Cake.Sdk first stabilised at 6.0.0, so this is the first per-major release where it can join the demo family. Lookup live before each Cake-6+ catch-up: at PR-open time (2026-05-07) latest is `6.1.1`. Pin uses `@` syntax (`Cake.Sdk@6.1.1`) per the file-based .NET program convention introduced in .NET 10.

## Why net8.0 stays the tests TFM

Per workspace memory `feedback_tests_tfm_rotation`: tests track the LOWEST supported TFM the addin ships at this Cake major. After this PR the addin still targets `net8.0;net9.0;net10.0` — `net8.0` is still the lowest, so no rotation. (Tests TFM only rotates when the addin's lowest TFM moves up.)

## Local verification

* `dotnet cake recipe.cake --target=DotNetCore-Pack` — `Cake.Coveralls.<ver>.nupkg` + `Cake.Coveralls.<ver>.snupkg` both produced cleanly. Zero warnings, zero errors.
* `dotnet cake recipe.cake --target=DotNetCore-Test` — 43/43 tests passing on `net8.0`.
* `./demo/script/build.ps1` — Settings-CoverallsIo + Settings-CoverallsNet + ReportType-Enums all pass (cake.tool 6.1.0).
* `./demo/frosting/build.ps1` — Settings-CoverallsIo + Settings-CoverallsNet + ReportType-Enums all pass (Cake.Frosting 6.1.0).
* `cd demo/sdk && dotnet cake.cs` — Settings-CoverallsIo + Settings-CoverallsNet + ReportType-Enums all pass (Cake.Sdk 6.1.1, source-built addin).

## Out of scope

This is the final per-Cake-major release in the catch-up arc.